### PR TITLE
fix bench ci error and enable ci lint github action

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -41,7 +41,7 @@ jobs:
         run: |
           go mod download
 
-      - name: Run ci lint
+      - name: Run CI lint
         run: make lint
 
       - name: Run test cover

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -41,5 +41,8 @@ jobs:
         run: |
           go mod download
 
+      - name: Run ci lint
+        run: make lint
+
       - name: Run test cover
         run: sh helper/test-cover.sh

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,8 +1,8 @@
 run:
   deadline: 5m
-  # skip-dirs:
-  #   - test
-  #   - examples
+  skip-dirs:
+    - test
+#    - bench
 
 linter-settings:
   goconst:

--- a/bench/main.go
+++ b/bench/main.go
@@ -21,7 +21,7 @@ usage:
 `
 
 func hintAndExit() {
-	fmt.Printf(usage)
+	fmt.Print(usage)
 	os.Exit(0)
 }
 


### PR DESCRIPTION
除了test目录之外的ci error基本修复完成，现为了防止在修复test过程中，其他模块新增又额外新增，先把CI lint的Action打开，并修改.golangci-lint的配置文件，将test目录跳过，带test修完之后，可关闭该配置项