### PR TITLE
optimization: config async update branch goroutine num

### DIFF
--- a/conf.sample.yml
+++ b/conf.sample.yml
@@ -48,6 +48,7 @@
 # TimeoutToFail: 35 # timeout for XA, TCC to fail. saga's timeout default to infinite, which can be overwritten in saga options
 # RetryInterval: 10 # the subtrans branch will be retried after this interval
 
+# UpdateBranchAsyncGoroutineNum: 1 # num of async goroutine to update branch status
 # LogLevel: 'info' # default: info. can be debug|info|warn|error
 # HttpPort: 36789
 # GrpcPort: 36790

--- a/dtmsvr/config/config.go
+++ b/dtmsvr/config/config.go
@@ -62,15 +62,16 @@ func (s *Store) GetDBConf() dtmcli.DBConf {
 }
 
 type configType struct {
-	Store             Store        `yaml:"Store"`
-	TransCronInterval int64        `yaml:"TransCronInterval" default:"3"`
-	TimeoutToFail     int64        `yaml:"TimeoutToFail" default:"35"`
-	RetryInterval     int64        `yaml:"RetryInterval" default:"10"`
-	HTTPPort          int64        `yaml:"HttpPort" default:"36789"`
-	GrpcPort          int64        `yaml:"GrpcPort" default:"36790"`
-	MicroService      MicroService `yaml:"MicroService"`
-	UpdateBranchSync  int64        `yaml:"UpdateBranchSync"`
-	LogLevel          string       `yaml:"LogLevel" default:"info"`
+	Store                         Store        `yaml:"Store"`
+	TransCronInterval             int64        `yaml:"TransCronInterval" default:"3"`
+	TimeoutToFail                 int64        `yaml:"TimeoutToFail" default:"35"`
+	RetryInterval                 int64        `yaml:"RetryInterval" default:"10"`
+	HTTPPort                      int64        `yaml:"HttpPort" default:"36789"`
+	GrpcPort                      int64        `yaml:"GrpcPort" default:"36790"`
+	MicroService                  MicroService `yaml:"MicroService"`
+	UpdateBranchSync              int64        `yaml:"UpdateBranchSync"`
+	UpdateBranchAsyncGoroutineNum int64        `yaml:"UpdateBranchAsyncGoroutineNum" default:"1"`
+	LogLevel                      string       `yaml:"LogLevel" default:"info"`
 }
 
 // Config 配置

--- a/dtmsvr/svr.go
+++ b/dtmsvr/svr.go
@@ -46,7 +46,10 @@ func StartSvr() {
 		err := s.Serve(lis)
 		logger.FatalIfError(err)
 	}()
-	go updateBranchAsync()
+
+	for i := 0; i < int(conf.UpdateBranchAsyncGoroutineNum); i++ {
+		go updateBranchAsync()
+	}
 
 	time.Sleep(100 * time.Millisecond)
 	err = dtmdriver.Use(conf.MicroService.Driver)


### PR DESCRIPTION
随着DTM单实例的TPS增加，异步分支更新数量增加，如果异步更新分支状态消费协程消费能力跟不上，则会导致channel上生产消息出现阻塞进而导致请求时延增大，最终会影响整体吞吐量；
这里异步协程配置数量，可以简单采用下面的公式计算：
1）单个异步协程每秒处理的分支数量：1000/一次批量处理分支事务更新时间（单位ms）* 20（每次批量操作更新的分支数）
2）异步协程配置数量：每秒TPS*分支事务数量/(单个异步协程每秒处理的分支数量)