### PR TITLE
fix helm deployment mount configMap name

### DIFF
--- a/charts/templates/deployment.yaml
+++ b/charts/templates/deployment.yaml
@@ -67,4 +67,4 @@ spec:
       volumes:
         - name: config
           configMap:
-            name: dtm-conf
+            name: {{ include "dtm.fullname" . }}-conf


### PR DESCRIPTION
修复安装 charts 时指定了 `dtm` 以外的名字，导致 deployment 挂载 configmap 失败。