### PR TITLE
优化mysql脚本

### DIFF
--- a/sqls/busi.mysql.sql
+++ b/sqls/busi.mysql.sql
@@ -11,7 +11,7 @@ create table if not exists dtm_busi.user_account(
   update_time datetime DEFAULT now(),
   key(create_time),
   key(update_time)
-);
+) ENGINE = InnoDB DEFAULT CHARSET = utf8mb4;
 insert into dtm_busi.user_account (user_id, balance)
 values (1, 10000),
   (2, 10000) on DUPLICATE KEY

--- a/sqls/dtmcli.barrier.mysql.sql
+++ b/sqls/dtmcli.barrier.mysql.sql
@@ -15,4 +15,4 @@ create table if not exists dtm_barrier.barrier(
   key(create_time),
   key(update_time),
   UNIQUE key(gid, branch_id, op, barrier_id)
-);
+) ENGINE = InnoDB DEFAULT CHARSET = utf8mb4;


### PR DESCRIPTION
关于此issue: [Issue 31](https://github.com/dtm-labs/dtm/issues/31)

导入mysql脚本错误。

引擎默认为MyIsam时会出现，指定脚本为Innodb引擎