### PR TITLE
optimize wait store up log

### DIFF
--- a/dtmsvr/storage/registry/registry.go
+++ b/dtmsvr/storage/registry/registry.go
@@ -49,7 +49,7 @@ func GetStore() storage.Store {
 // WaitStoreUp wait for db to go up
 func WaitStoreUp() {
 	for err := GetStore().Ping(); err != nil; err = GetStore().Ping() {
-		time.Sleep(3 * time.Second)
 		logger.Infof("wait store up")
+		time.Sleep(3 * time.Second)
 	}
 }

--- a/dtmsvr/storage/registry/registry.go
+++ b/dtmsvr/storage/registry/registry.go
@@ -3,6 +3,8 @@ package registry
 import (
 	"time"
 
+	"github.com/dtm-labs/dtm/dtmcli/logger"
+
 	"github.com/dtm-labs/dtm/dtmsvr/config"
 	"github.com/dtm-labs/dtm/dtmsvr/storage"
 	"github.com/dtm-labs/dtm/dtmsvr/storage/boltdb"
@@ -48,5 +50,6 @@ func GetStore() storage.Store {
 func WaitStoreUp() {
 	for err := GetStore().Ping(); err != nil; err = GetStore().Ping() {
 		time.Sleep(3 * time.Second)
+		logger.Infof("wait store up")
 	}
 }


### PR DESCRIPTION
When the store is not started, the program has no output and is blocked in `WaitStoreUp`, and the problem cannot be detected in time.