### PR TITLE
feat: DBConf增加DB配置

### DIFF
--- a/dtmcli/dtmimp/types.go
+++ b/dtmcli/dtmimp/types.go
@@ -21,4 +21,5 @@ type DBConf struct {
 	Port     int64  `yaml:"Port"`
 	User     string `yaml:"User"`
 	Password string `yaml:"Password"`
+	Db       string `yaml:"Db"`
 }

--- a/dtmcli/dtmimp/utils.go
+++ b/dtmcli/dtmimp/utils.go
@@ -210,9 +210,9 @@ func GetDsn(conf DBConf) string {
 	driver := conf.Driver
 	dsn := map[string]string{
 		"mysql": fmt.Sprintf("%s:%s@tcp(%s:%d)/%s?charset=utf8mb4&parseTime=true&loc=Local&interpolateParams=true",
-			conf.User, conf.Password, host, conf.Port, ""),
+			conf.User, conf.Password, host, conf.Port, conf.Db),
 		"postgres": fmt.Sprintf("host=%s user=%s password=%s dbname='%s' port=%d sslmode=disable",
-			host, conf.User, conf.Password, "", conf.Port),
+			host, conf.User, conf.Password, conf.Db, conf.Port),
 	}[driver]
 	PanicIf(dsn == "", fmt.Errorf("unknow driver: %s", driver))
 	return dsn


### PR DESCRIPTION
DBConf增加DB配置。
主要原因是在 postgresql 使用上不是很方便，有时候在测试环境下可能只有一个账户，但是dtm默认的配置需要 一个用户对应一个db.在开发的时候很不方便，一个微服务的db都要单独设置和创建用户。如果有几十个微服务db就要创建几十个帐号。在开发阶段确实很难受。