### PR TITLE
Make the nil and empty of the `BinPayload` equivalent

### DIFF
--- a/dtmsvr/trans_status.go
+++ b/dtmsvr/trans_status.go
@@ -141,11 +141,15 @@ func (t *TransGlobal) getHTTPResult(uri string, branchID, op string, branchPaylo
 		SetHeader("Content-type", "application/json").
 		SetHeaders(t.Ext.Headers).
 		SetHeaders(t.TransOptions.BranchHeaders).
-		Execute(dtmimp.If(!dtmutil.IsEmptyBinData(branchPayload) || t.TransType == "xa", "POST", "GET").(string), uri)
+		Execute(t.determineHttpRequestMethod(branchPayload), uri)
 	if err != nil {
 		return err
 	}
 	return dtmcli.HTTPResp2DtmError(resp)
+}
+
+func (t *TransGlobal) determineHttpRequestMethod(branchPayload []byte) string {
+	return dtmimp.If(len(branchPayload) != 0 || t.TransType == "xa", "POST", "GET").(string)
 }
 
 func (t *TransGlobal) getJSONRPCResult(uri string, branchID, op string, branchPayload []byte) error {

--- a/dtmsvr/trans_status.go
+++ b/dtmsvr/trans_status.go
@@ -141,7 +141,7 @@ func (t *TransGlobal) getHTTPResult(uri string, branchID, op string, branchPaylo
 		SetHeader("Content-type", "application/json").
 		SetHeaders(t.Ext.Headers).
 		SetHeaders(t.TransOptions.BranchHeaders).
-		Execute(dtmimp.If(!dtmutil.IsEmptyBinPayload(branchPayload) || t.TransType == "xa", "POST", "GET").(string), uri)
+		Execute(dtmimp.If(!dtmutil.IsEmptyBinData(branchPayload) || t.TransType == "xa", "POST", "GET").(string), uri)
 	if err != nil {
 		return err
 	}

--- a/dtmsvr/trans_status.go
+++ b/dtmsvr/trans_status.go
@@ -141,7 +141,7 @@ func (t *TransGlobal) getHTTPResult(uri string, branchID, op string, branchPaylo
 		SetHeader("Content-type", "application/json").
 		SetHeaders(t.Ext.Headers).
 		SetHeaders(t.TransOptions.BranchHeaders).
-		Execute(dtmimp.If(branchPayload != nil || t.TransType == "xa", "POST", "GET").(string), uri)
+		Execute(dtmimp.If(!dtmutil.IsEmptyBinPayload(branchPayload) || t.TransType == "xa", "POST", "GET").(string), uri)
 	if err != nil {
 		return err
 	}

--- a/dtmutil/utils.go
+++ b/dtmutil/utils.go
@@ -176,5 +176,5 @@ func RunSQLScript(conf dtmcli.DBConf, script string, skipDrop bool) {
 
 // IsEmptyBinData returns true if the bin data is nil or empty
 func IsEmptyBinData(binPayload []byte) bool {
-	return binPayload == nil || len(binPayload) == 0
+	return len(binPayload) == 0
 }

--- a/dtmutil/utils.go
+++ b/dtmutil/utils.go
@@ -173,3 +173,8 @@ func RunSQLScript(conf dtmcli.DBConf, script string, skipDrop bool) {
 		logger.Infof("sql scripts finished: %s", s)
 	}
 }
+
+// IsEmptyBinPayload returns true if the bin data is nil or empty
+func IsEmptyBinPayload(binPayload []byte) bool {
+	return binPayload == nil || len(binPayload) == 0
+}

--- a/dtmutil/utils.go
+++ b/dtmutil/utils.go
@@ -173,8 +173,3 @@ func RunSQLScript(conf dtmcli.DBConf, script string, skipDrop bool) {
 		logger.Infof("sql scripts finished: %s", s)
 	}
 }
-
-// IsEmptyBinData returns true if the bin data is nil or empty
-func IsEmptyBinData(binPayload []byte) bool {
-	return len(binPayload) == 0
-}

--- a/dtmutil/utils.go
+++ b/dtmutil/utils.go
@@ -174,7 +174,7 @@ func RunSQLScript(conf dtmcli.DBConf, script string, skipDrop bool) {
 	}
 }
 
-// IsEmptyBinPayload returns true if the bin data is nil or empty
-func IsEmptyBinPayload(binPayload []byte) bool {
+// IsEmptyBinData returns true if the bin data is nil or empty
+func IsEmptyBinData(binPayload []byte) bool {
 	return binPayload == nil || len(binPayload) == 0
 }


### PR DESCRIPTION
This PR is fixing the problem of the DTM server misdetermining a branch action with a "GET" request as a "POST" request due to the `BinPayload` being an empty byte array but not `nil`.