### PR TITLE
Fix worflow conversion

### DIFF
--- a/client/workflow/workflow.go
+++ b/client/workflow/workflow.go
@@ -227,7 +227,7 @@ func (wf *Workflow) DoXa(dbConf dtmcli.DBConf, fn func(db *sql.DB) ([]byte, erro
 // Interceptor is the middleware for workflow to capture grpc call result
 func Interceptor(ctx context.Context, method string, req, reply interface{}, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
 	logger.Debugf("grpc client calling: %s%s %v", cc.Target(), method, dtmimp.MustMarshalString(req))
-	wf := ctx.Value(wfMeta{}).(*Workflow)
+	wf, _ := ctx.Value(wfMeta{}).(*Workflow)
 	if wf == nil {
 		return nil
 	}


### PR DESCRIPTION
Hi, that conversion is causing a panic when the result of `Value()` is nil