### PR TITLE
Call invoker if Workflow is nil

### DIFF
--- a/client/workflow/workflow.go
+++ b/client/workflow/workflow.go
@@ -229,7 +229,7 @@ func Interceptor(ctx context.Context, method string, req, reply interface{}, cc 
 	logger.Debugf("grpc client calling: %s%s %v", cc.Target(), method, dtmimp.MustMarshalString(req))
 	wf, _ := ctx.Value(wfMeta{}).(*Workflow)
 	if wf == nil {
-		return nil
+		return invoker(ctx, method, req, reply, cc, opts...)
 	}
 
 	origin := func() error {

--- a/test/workflow_interceptor_test.go
+++ b/test/workflow_interceptor_test.go
@@ -1,0 +1,19 @@
+package test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/dtm-labs/dtm/client/workflow"
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/grpc"
+)
+
+func TestWorkflowInterceptorOutsideSaga(t *testing.T) {
+	called := false
+	workflow.Interceptor(context.TODO(), "method", nil, nil, nil, func(ctx context.Context, method string, req, reply interface{}, cc *grpc.ClientConn, opts ...grpc.CallOption) error {
+		called = true
+		return nil
+	})
+	assert.True(t, called)
+}

--- a/test/workflow_interceptor_test.go
+++ b/test/workflow_interceptor_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestWorkflowInterceptorOutsideSaga(t *testing.T) {
 	called := false
-	workflow.Interceptor(context.TODO(), "method", nil, nil, nil, func(ctx context.Context, method string, req, reply interface{}, cc *grpc.ClientConn, opts ...grpc.CallOption) error {
+	workflow.Interceptor(context.TODO(), "method", nil, nil, &grpc.ClientConn{}, func(ctx context.Context, method string, req, reply interface{}, cc *grpc.ClientConn, opts ...grpc.CallOption) error {
 		called = true
 		return nil
 	})


### PR DESCRIPTION
In a previous PR, I fixed a panic occuring when the client is not used inside saga.
Now, I noticed that returning nil when no `Worfklow` is found has the effect of skipping the grpc call, which is not what we want when we use the client outside saga: client should behave like if no interceptor was there outside saga.
@yedf2: can you confirm that calling invoker the way I'm doing has the effect of completing the call?