### PR TITLE
Change the time field of sql to parameters（sql版的storage实现对于时间字段改为参数化）

### DIFF
--- a/dtmsvr/storage/sql/sql.go
+++ b/dtmsvr/storage/sql/sql.go
@@ -311,6 +311,7 @@ func wrapError(err error) error {
 	return err
 }
 
+// gorm driver to format sql time
 func getAfterTime(afterSecond int64) *time.Time {
 	return dtmutil.GetNextTime(afterSecond)
 }


### PR DESCRIPTION
sql版的storage实现，对于时间字段，手写sql都是通过Format("2006-01-02 15:04:05")来硬编码时间格式的sql拼接，丢失了gorm框架通过各driver对时间类型的处理（如时区等）。在对接gorm.io/driver/sqlserver时暴露了此硬编码的问题，随先进行修改。

**副作用：之前调试信息可打印出拼接好的sql，本次修改后估计只能打印参数化之前的模板**

