### PR TITLE
Optimize Map2Kvs functions by pre-allocating memory

### DIFF
--- a/client/dtmgrpc/dtmgimp/utils.go
+++ b/client/dtmgrpc/dtmgimp/utils.go
@@ -77,7 +77,7 @@ func TransInfo2Ctx(ctx context.Context, gid, transType, branchID, op, dtm string
 
 // Map2Kvs map to metadata kv
 func Map2Kvs(m map[string]string) []string {
-	kvs := make([]string, 0, len(m)<<1)
+	kvs := make([]string, 0, len(m)*2)
 	for k, v := range m {
 		kvs = append(kvs, k, v)
 	}

--- a/client/dtmgrpc/dtmgimp/utils.go
+++ b/client/dtmgrpc/dtmgimp/utils.go
@@ -7,14 +7,14 @@
 package dtmgimp
 
 import (
-	context "context"
+	"context"
 
 	"github.com/dtm-labs/dtm/client/dtmcli/dtmimp"
 	"github.com/dtm-labs/dtm/client/dtmgrpc/dtmgpb"
 	"github.com/dtm-labs/logger"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/protobuf/proto"
-	emptypb "google.golang.org/protobuf/types/known/emptypb"
+	"google.golang.org/protobuf/types/known/emptypb"
 )
 
 // MustProtoMarshal must version of proto.Marshal
@@ -77,7 +77,7 @@ func TransInfo2Ctx(ctx context.Context, gid, transType, branchID, op, dtm string
 
 // Map2Kvs map to metadata kv
 func Map2Kvs(m map[string]string) []string {
-	kvs := []string{}
+	kvs := make([]string, 0, len(m)<<1)
 	for k, v := range m {
 		kvs = append(kvs, k, v)
 	}


### PR DESCRIPTION
goos: windows
goarch: amd64
pkg: [github.com/dtm-labs/dtm/client/dtmgrpc/dtmgimp](http://github.com/dtm-labs/dtm/client/dtmgrpc/dtmgimp)
cpu: Intel(R) Core(TM) i7-10700 CPU @ 2.90GHz
BenchmarkMap2Kvs
BenchmarkMap2Kvs-16    	  61436	   19822 ns/op
BenchmarkMap2KvsOld
BenchmarkMap2KvsOld-16  	  30886	   38553 ns/op
PASS

```go
package dtmgimp

import (
	"math/rand"
	"testing"
)

const letterBytes = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"

func RandStringBytes(n int) string {
	b := make([]byte, n)
	for i := range b {
		b[i] = letterBytes[rand.Intn(len(letterBytes))]
	}
	return string(b)
}

var m = func() map[string]string {
	m := make(map[string]string)
	for i := 0; i < 1000; i++ {
		m[RandStringBytes(100)] = "exist"
	}
	return m
}()

// Map2Kvs map to metadata kv
func Map2KvsNew(m map[string]string) []string {
	kvs := make([]string, 0, len(m)<<1)
	for k, v := range m {
		kvs = append(kvs, k, v)
	}
	return kvs
}

// Map2Kvs map to metadata kv
func Map2KvsOld(m map[string]string) []string {
	kvs := []string{}
	for k, v := range m {
		kvs = append(kvs, k, v)
	}
	return kvs
}

func BenchmarkMap2Kvs(b *testing.B) {
	for i := 0; i < b.N; i++ {
		_ = Map2KvsNew(m)
	}
}

func BenchmarkMap2KvsOld(b *testing.B) {
	for i := 0; i < b.N; i++ {
		_ = Map2KvsOld(m)
	}
}

```
