### PR TITLE
refactor: migrate from io/ioutil to io and os

### DIFF
--- a/client/workflow/utils.go
+++ b/client/workflow/utils.go
@@ -3,7 +3,7 @@ package workflow
 import (
 	"bytes"
 	"errors"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strconv"
 
@@ -71,8 +71,8 @@ func newRoundTripper(old http.RoundTripper, wf *Workflow) http.RoundTripper {
 // HTTPResp2DtmError check for dtm error and return it
 func HTTPResp2DtmError(resp *http.Response) ([]byte, error) {
 	code := resp.StatusCode
-	data, err := ioutil.ReadAll(resp.Body)
-	resp.Body = ioutil.NopCloser(bytes.NewBuffer(data))
+	data, err := io.ReadAll(resp.Body)
+	resp.Body = io.NopCloser(bytes.NewBuffer(data))
 	if code == http.StatusTooEarly {
 		return data, dtmcli.ErrorMessage2Error(string(data), dtmcli.ErrOngoing)
 	} else if code == http.StatusConflict {

--- a/dtmsvr/config/config.go
+++ b/dtmsvr/config/config.go
@@ -2,7 +2,7 @@ package config
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"os"
 
 	"github.com/dtm-labs/dtm/client/dtmcli"
 	"github.com/dtm-labs/logger"
@@ -113,7 +113,7 @@ var Config = Type{}
 func MustLoadConfig(confFile string) {
 	loadFromEnv("", &Config)
 	if confFile != "" {
-		cont, err := ioutil.ReadFile(confFile)
+		cont, err := os.ReadFile(confFile)
 		logger.FatalIfError(err)
 		err = yaml.Unmarshal(cont, &Config)
 		logger.FatalIfError(err)

--- a/dtmutil/utils.go
+++ b/dtmutil/utils.go
@@ -10,7 +10,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -37,7 +37,7 @@ func GetGinApp() *gin.Engine {
 			dtmimp.E2P(err)
 			if len(rb) > 0 {
 				body = string(rb)
-				c.Request.Body = ioutil.NopCloser(bytes.NewBuffer(rb))
+				c.Request.Body = io.NopCloser(bytes.NewBuffer(rb))
 			}
 		}
 		logger.Debugf("begin %s %s body: %s", c.Request.Method, c.Request.URL, body)
@@ -160,7 +160,7 @@ func RunSQLScript(conf dtmcli.DBConf, script string, skipDrop bool) {
 	con, err := dtmimp.StandaloneDB(conf)
 	logger.FatalIfError(err)
 	defer func() { _ = con.Close() }()
-	content, err := ioutil.ReadFile(script)
+	content, err := os.ReadFile(script)
 	logger.FatalIfError(err)
 	sqls := strings.Split(string(content), ";")
 	for _, sql := range sqls {

--- a/test/busi/base_http.go
+++ b/test/busi/base_http.go
@@ -10,7 +10,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"strings"
 
 	"github.com/dtm-labs/dtm/client/dtmcli"
@@ -86,7 +86,7 @@ func RunHTTP(app *gin.Engine) {
 // BaseAddRoute add base route handler
 func BaseAddRoute(app *gin.Engine) {
 	app.POST(BusiAPI+"/workflow/resume", dtmutil.WrapHandler(func(ctx *gin.Context) interface{} {
-		data, err := ioutil.ReadAll(ctx.Request.Body)
+		data, err := io.ReadAll(ctx.Request.Body)
 		logger.FatalIfError(err)
 		return workflow.ExecuteByQS(ctx.Request.URL.Query(), data)
 	}))


### PR DESCRIPTION
- Replaced deprecated io/ioutil functions with their equivalents in io and os packages
- This change aligns with Go 1.16+ recommendations to avoid using io/ioutil
- Updated affected code and tests to ensure compatibility